### PR TITLE
Dockerfile for tabix based on our samtools image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM mgibio/samtools:1.3.1
+MAINTAINER Thomas B. Mooney <tmooney@genome.wustl.edu>
+
+LABEL \
+  version="1.3.1" \
+  description="Tabix image for use in Workflows"
+
+RUN ln -s $SAMTOOLS_INSTALL_DIR/bin/tabix /usr/bin/tabix
+ENTRYPOINT ["/usr/bin/tabix"]


### PR DESCRIPTION
This takes the image from genome/docker-samtools#1 and switches the entrypoint to tabix.
